### PR TITLE
TRITON-2415 Add lxd to list of valid image types

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -6,7 +6,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
- * Copyright 2022 MNX Cloud, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 /*
@@ -38,6 +38,8 @@ var apertureConfig = require('aperture-config').config;
 
 
 // --- Globals
+
+var VALID_IMG_TYPES = ['zone-dataset', 'lx-dataset', 'zvol', 'docker', 'lxd'];
 
 var SDC_128_PACKAGE = {
     uuid: '897779dc-9ce7-4042-8879-a4adccc94353',
@@ -1347,6 +1349,8 @@ module.exports = {
     kvm_128_package: KVM_128_PACKAGE,
     bhyve_128_package: BHYVE_128_PACKAGE,
     bhyve_128_flex_package: BHYVE_128_FLEX_PACKAGE,
+
+    validImgTypes: VALID_IMG_TYPES,
 
     getCfg: function () {
         return CONFIG;

--- a/test/images.80.test.js
+++ b/test/images.80.test.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 var test = require('tape');
@@ -44,8 +45,7 @@ function checkImage(t, image, path) {
 
     t.equal(typeof (image.urn), 'undefined', 'image.urn');
     t.equal(typeof (image.default), 'undefined', 'image.default');
-    var expectedTypes = ['zone-dataset', 'lx-dataset', 'zvol', 'docker'];
-    t.ok(expectedTypes.indexOf(image.type) !== -1,
+    t.ok(common.validImgTypes.indexOf(image.type) !== -1,
         'expected image.type: ' + image.type);
 }
 

--- a/test/images.test.js
+++ b/test/images.test.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 var test = require('tape');
@@ -44,8 +45,7 @@ function checkImage(t, image, path) {
 
     t.equal(typeof (image.urn), 'undefined', 'image.urn');
     t.equal(typeof (image.default), 'undefined', 'image.default');
-    var expectedTypes = ['zone-dataset', 'lx-dataset', 'zvol', 'docker'];
-    t.ok(expectedTypes.indexOf(image.type) !== -1,
+    t.ok(common.validImgTypes.indexOf(image.type) !== -1,
         'expected image.type: ' + image.type);
 }
 


### PR DESCRIPTION
Prevent tests from failing if lxd images (for LinuxCN) are installed.

After making this change, multiple tests that were failing with the following error no longer fail:

```
not ok 174 expected image.type: lxd
  ---
    operator: ok
    expected: true
    actual:   false
    at: checkImage (/opt/smartdc/cloudapi/test/images.80.test.js:48:7)
    stack: |-
      Error: expected image.type: lxd
          at Test.assert [as _assert] (/opt/smartdc/cloudapi/node_modules/tape/lib/test.js:228:54)
          at Test.bound [as _assert] (/opt/smartdc/cloudapi/node_modules/tape/lib/test.js:80:32)
          at Test.assert (/opt/smartdc/cloudapi/node_modules/tape/lib/test.js:347:10)
          at Test.bound [as ok] (/opt/smartdc/cloudapi/node_modules/tape/lib/test.js:80:32)
          at checkImage (/opt/smartdc/cloudapi/test/images.80.test.js:48:7)
          at /opt/smartdc/cloudapi/test/images.80.test.js:99:13
          at Array.forEach (native)
          at /opt/smartdc/cloudapi/test/images.80.test.js:98:14
          at parseResponse (/opt/smartdc/cloudapi/node_modules/restify/lib/clients/json_client.js:91:9)
          at IncomingMessage.done (/opt/smartdc/cloudapi/node_modules/restify/lib/clients/string_client.js:167:13)
  ...
  ```
  
I also confirmed that they still pass if lxd images _are not_ present.
  
I am not yet getting the entirety of the cloudapi tests to pass locally but will tackle those issues in future PRs.