### PR TITLE
TRITON-2417 Add support for ED25519 keys

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -71,6 +71,7 @@ var SIGN_ALGOS = {
     'ECDSA-SHA256': true,
     'ECDSA-SHA384': true,
     'ECDSA-SHA512': true,
+    'ED25519-SHA256': true,
     'ED25519-SHA512': true
 };
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -70,7 +70,8 @@ var SIGN_ALGOS = {
     'DSA-SHA256': true,
     'ECDSA-SHA256': true,
     'ECDSA-SHA384': true,
-    'ECDSA-SHA512': true
+    'ECDSA-SHA512': true,
+    'ED25519-SHA512': true
 };
 
 // --- Messages

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -71,7 +71,6 @@ var SIGN_ALGOS = {
     'ECDSA-SHA256': true,
     'ECDSA-SHA384': true,
     'ECDSA-SHA512': true,
-    'ED25519-SHA256': true,
     'ED25519-SHA512': true
 };
 

--- a/lib/authorization.js
+++ b/lib/authorization.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 /*
@@ -37,6 +38,7 @@ var OPTIONS = {
         'ecdsa-sha256',
         'ecdsa-sha384',
         'ecdsa-sha512',
+        'ed25519-sha256',
         'ed25519-sha512'
     ]
 };

--- a/lib/authorization.js
+++ b/lib/authorization.js
@@ -36,7 +36,8 @@ var OPTIONS = {
         'dsa-sha256',
         'ecdsa-sha256',
         'ecdsa-sha384',
-        'ecdsa-sha512'
+        'ecdsa-sha512',
+        'ed25519-sha512'
     ]
 };
 

--- a/lib/authorization.js
+++ b/lib/authorization.js
@@ -38,7 +38,6 @@ var OPTIONS = {
         'ecdsa-sha256',
         'ecdsa-sha384',
         'ecdsa-sha512',
-        'ed25519-sha256',
         'ed25519-sha512'
     ]
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ctype": "^0.5.5",
     "cueball": "2.10.1",
     "filed": "0.0.7",
-    "http-signature": "1.3.6",
+    "http-signature": "https://github.com/TritonDataCenter/node-http-signature.git#5d8dc05d4e0ec3421bbf40b35be5a30152749638",
     "joyent-schemas": "git+https://github.com/TritonDataCenter/schemas.git#3ca3a09c8b6f29ee68ba17d61b556b6f2901a4b6",
     "jsprim": "2.0.2",
     "kang": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ctype": "^0.5.5",
     "cueball": "2.10.1",
     "filed": "0.0.7",
-    "http-signature": "https://github.com/TritonDataCenter/node-http-signature.git#a08360e",
+    "http-signature": "1.4.0",
     "joyent-schemas": "git+https://github.com/TritonDataCenter/schemas.git#3ca3a09c8b6f29ee68ba17d61b556b6f2901a4b6",
     "jsprim": "2.0.2",
     "kang": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ctype": "^0.5.5",
     "cueball": "2.10.1",
     "filed": "0.0.7",
-    "http-signature": "https://github.com/TritonDataCenter/node-http-signature.git#5d8dc05d4e0ec3421bbf40b35be5a30152749638",
+    "http-signature": "https://github.com/TritonDataCenter/node-http-signature.git#a08360e",
     "joyent-schemas": "git+https://github.com/TritonDataCenter/schemas.git#3ca3a09c8b6f29ee68ba17d61b556b6f2901a4b6",
     "jsprim": "2.0.2",
     "kang": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudapi",
   "description": "Triton CloudAPI",
-  "version": "9.17.0",
+  "version": "9.18.0",
   "author": "MNX Cloud (mnx.io)",
   "private": true,
   "engines": {


### PR DESCRIPTION
**Testing Notes**
- Confirmed that `make check` succeeded.
- Installed changes via `sdcadm up -C experimental cloudapi@TRITON-2378-20231206T170927Z-gee2e002`
- Ran the integration tests on my local headnode and confirmed that there are no new failures (there are a few unrelated failures that were failing before these changes and will be fixed separately e.g. TRITON-2415, TRITON-2416)
- Updated sshpk in [sdc-ufds](https://github.com/TritonDataCenter/sdc-ufds/compare/TRITON-2378) and confirmed that make check succeeded and that I could install the changes via `sdcadm update -C experimental ufds@TRITON-2378-20231116T205537Z-g5fb2ee0`
- I then updated sskpk-agent and smartdc-auth to latest in [node-triton](https://github.com/TritonDataCenter/node-triton/compare/TRITON-2378), removed all keys from my account except for an ED25519 key and confirmed that I could make Cloud API requests, provision an instance, and ssh into it (provided a CN with an image containing OS-8502 was used.)
- I also used [smartdc-auth](https://github.com/TritonDataCenter/node-smartdc-auth/blob/a257d55ae50be8ef340bd5e297f842bc73111a0f/README.md#keypaircreatesignoptions) to generate a signed CloudAPI URL and confirmed the URL was authenticated and returned the expected response.

Worth noting that these changes have also been used while testing the following PRs: 
- TritonDataCenter/node-smartdc-auth/pull/19
- TritonDataCenter/node-http-signature/pull/132